### PR TITLE
[BE] #9 github action 파이프라인 배포 시 clone url 타입 변경

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -52,5 +52,5 @@ jobs:
               strategy: rolling
             context:
               git:
-                url: git@github.com:${{ github.repository }}.git
+                url: https://github.com/${{ github.repository }}.git
                 ref: ${{ github.ref }}


### PR DESCRIPTION
- ssh 인증은 막아놨기에 https url 형식으로 변경